### PR TITLE
Update playbook to work with new Ansible versions

### DIFF
--- a/tasks/cli.yml
+++ b/tasks/cli.yml
@@ -3,7 +3,7 @@
 # If Jenkins is installed or updated, wait for pulling the Jenkins CLI, assuming 10s should be sufficiant
 - name: 10s delay while starting Jenkins
   wait_for: port=8080 delay=10
-  only_if: ${jenkins_install.changed}
+  when: ${jenkins_install.changed}
   tags:
     - jenkins
     - cli
@@ -33,7 +33,7 @@
 # Jenkins Update-center
 - name: Update-center Jenkins
   shell: "cat ${jenkins.updates_dest} | sed '1d;$d' | curl -X POST -H 'Accept: application/json' -d @- http://localhost:8080/updateCenter/byId/default/postBack"
-  only_if: ${jenkins_updates.changed}
+  when: ${jenkins_updates.changed}
   tags:
     - jenkins
     - cli
@@ -41,7 +41,7 @@
 # Install/update Jenkins plugins
 - name: Install/update plugins
   command: java -jar ${jenkins.cli_dest} -s http://localhost:8080 install-plugin ${item}
-  only_if: is_set("$plugins") and ${jenkins_updates.changed}
+  when: is_set("$plugins") and ${jenkins_updates.changed}
   with_items: $plugins
   tags:
     - jenkins
@@ -50,7 +50,7 @@
 # Wait for Jenkins to install plugins, assuming 10s should be sufficiant
 - name: 10s delay while installing plugins
   wait_for: port=8080 delay=10
-  only_if: ${jenkins_updates.changed}
+  when: ${jenkins_updates.changed}
   tags:
     - jenkins
     - cli
@@ -58,7 +58,7 @@
 # Safe-restart Jenkins
 - name: Safe-restart Jenkins
   command: java -jar ${jenkins.cli_dest} -s http://localhost:8080 safe-restart
-  only_if: ${jenkins_updates.changed}
+  when: ${jenkins_updates.changed}
   tags:
     - jenkins
     - cli

--- a/tasks/cli.yml
+++ b/tasks/cli.yml
@@ -41,7 +41,7 @@
 # Install/update Jenkins plugins
 - name: Install/update plugins
   command: java -jar ${jenkins.cli_dest} -s http://localhost:8080 install-plugin ${item}
-  when: is_set("$plugins") and ${jenkins_updates.changed}
+  when: when $plugins is defined and ${jenkins_updates.changed}
   with_items: $plugins
   tags:
     - jenkins

--- a/tasks/setup.yml
+++ b/tasks/setup.yml
@@ -1,9 +1,9 @@
 ---
 # Add Jenkins repository
-- include: tasks/repo.yml
+- include: repo.yml
 
 # Install dependencies
-- include: tasks/dependencies.yml
+- include: dependencies.yml
 
 # Install Jenkins
 - name: Install Jenkins
@@ -13,4 +13,4 @@
     - packages
 
 # Install Jenkins cli
-- include: tasks/cli.yml
+- include: cli.yml


### PR DESCRIPTION
While running this playbook under Ansible 1.2 and 1.3 I've encountered a bunch of errors:
1. `ERROR: file not found: <base path>/ansible-jenkins/tasks/tasks/repo.yml`
2. `fatal: [host] => Conditional expression must evaluate to True or False: ${jenkins_install.changed}`
3. `fatal: [host] => error while evaluating conditional: {% if is_set("ldap,github,translation,preSCMbuildstep") and True %} True {% else %} False {% endif %}`

All of those errors are related to using syntax which is not supported anymore in newer versions.

This branch fixes those issues and updates the playbook to work with newer Ansible versions. It does the following:
1. Fixes the include paths.
2. Uses `when` instead of old `only_if`
3. Uses `when $variable defined` instead of old `is_set` syntax
