### PR TITLE
Adjusts the shared-role for RBL

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,8 +1,57 @@
 ---
 placeholder: 'placeholder'
-# plugins:
-#   - 'ldap'
-#   - 'github'
-#   - 'translation'
-#   - 'preSCMbuildstep'
-#   - 'gravatar'
+plugins:
+  - ansicolor
+  - ant
+  - build-cause-run-condition
+  - build-name-setter
+  - build-pipeline-plugin
+  - build-timeout
+  - campfire
+  - chucknorris
+  - clone-workspace-scm
+  - conditional-buildstep
+  - copyartifact
+  - credentials
+  - cvs
+  - downstream-ext
+  - envinject
+  - external-monitor-job
+  - ghprb
+  - git
+  - git-client
+  - github
+  - github-api
+  - github-oauth
+  - gitlab-hook
+  - git-parameter
+  - gravatar
+  - greenballs
+  - heavy-job
+  - javadoc
+  - jenkins-leiningen
+  - jquery
+  - ldap
+  - mailer
+  - maven-plugin
+  - msbuild
+  - nunit
+  - pam-auth
+  - parameterized-trigger
+  - powershell
+  - rbenv
+  - ruby-runtime
+  - run-condition
+  - s3
+  - scm-sync-configuration
+  - sms-notification
+  - ssh-agent
+  - ssh-credentials
+  - ssh-slaves
+  - subversion
+  - text-finder-run-condition
+  - token-macro
+  - translation
+  - versionnumber
+  - view-job-filters
+jenkins_startup_delay: 10 # in seconds

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - oracle-java7

--- a/tasks/cli.yml
+++ b/tasks/cli.yml
@@ -1,8 +1,8 @@
 ---
 # Handle plugins
 # If Jenkins is installed or updated, wait for pulling the Jenkins CLI, assuming 10s should be sufficiant
-- name: 10s delay while starting Jenkins
-  wait_for: port=8080 delay=10
+- name: "{{ jenkins.startup_delay }}s delay while starting Jenkins"
+  wait_for: port=8080 delay={{ jenkins_startup_delay }}
   when: jenkins_install.changed
 
 # Create Jenkins CLI destination directory

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -3,8 +3,6 @@ jenkins:
   repo: 'deb http://pkg.jenkins-ci.org/debian binary/' # Jenkins repository
   key: 'http://pkg.jenkins-ci.org/debian/jenkins-ci.org.key' # Jenkins key
   dependencies: # Jenkins dependencies
-    - 'openjdk-6-jre'
-    - 'openjdk-6-jdk'
     - 'git'
     - 'curl'
   dest: '/opt/jenkins'


### PR DESCRIPTION
- Parameterizes the startup wait, useful on vagrant hosts
- Removes the installation of openjdk6, so we can use our oracle java
  7 jre
- Adds dependencies for our oracle java 7 jre
- Installs plugins used by RBL

This will be joined by a PR for the Jenkins shared role.
