### PR TITLE
Syntax deprecation.

### DIFF
--- a/tasks/cli.yml
+++ b/tasks/cli.yml
@@ -8,7 +8,7 @@
 # Create Jenkins CLI destination directory
 - name: "Create Jenkins CLI destination directory: ${jenkins.dest}"
   sudo: yes
-  action: file path={{ jenkins.dest }} state=directory
+  action: file path={{ jenkins_dest }} state=directory
 
 # Get Jenkins CLI from localhost
 - name: Get Jenkins CLI

--- a/tasks/dependencies_deb.yml
+++ b/tasks/dependencies_deb.yml
@@ -2,5 +2,5 @@
 # Install Jenkins dependencies
 - name: Install dependencies
   sudo: yes
-  action: ${ansible_pkg_mgr} pkg={{ item }} state=installed update-cache=yes
+  action: "{{ ansible_pkg_mgr }} pkg={{ item }} state=installed update-cache=yes"
   with_items: jenkins.deb.dependencies

--- a/tasks/jenkins.yml
+++ b/tasks/jenkins.yml
@@ -1,6 +1,6 @@
 ---
 # Add Jenkins repository
-- include: repo.yml 
+- include: repo.yml
   when: ansible_distribution in [ 'Debian', 'Ubuntu' ]
 
 # Install dependencies
@@ -10,7 +10,7 @@
 # Install Jenkins
 - name: Install Jenkins
   sudo: yes
-  action: ${ansible_pkg_mgr} pkg=jenkins state=latest update-cache=yes
+  action: {{ ansible_pkg_mgr }} pkg=jenkins state=latest update-cache=yes
   when: ansible_distribution in [ 'Debian', 'Ubuntu' ]
   register: jenkins_install
 

--- a/tasks/jenkins.yml
+++ b/tasks/jenkins.yml
@@ -10,7 +10,7 @@
 # Install Jenkins
 - name: Install Jenkins
   sudo: yes
-  action: {{ ansible_pkg_mgr }} pkg=jenkins state=latest update-cache=yes
+  action: "{{ ansible_pkg_mgr }} pkg=jenkins state=latest update-cache=yes"
   when: ansible_distribution in [ 'Debian', 'Ubuntu' ]
   register: jenkins_install
 

--- a/tasks/repo.yml
+++ b/tasks/repo.yml
@@ -2,7 +2,7 @@
 # Provides add-apt-repository
 - name: Install python-software-properties
   sudo: yes
-  action: ${ansible_pkg_mgr} pkg=python-software-properties state=installed update-cache=yes
+  action: "{{ ansible_pkg_mgr }} pkg=python-software-properties state=installed update-cache=yes"
 
 # Add Jenkins repository key
 - name: Add jenkins apt-key

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,4 +1,5 @@
 ---
+jenkins_dest: /opt/jenkins
 jenkins:
   deb:
     repo: 'deb http://pkg.jenkins-ci.org/debian binary/' # Jenkins repository
@@ -8,6 +9,5 @@ jenkins:
       - 'openjdk-7-jdk'
       - 'git'
       - 'curl'
-  dest: '/opt/jenkins'
-  cli_dest: '{{ jenkins.dest }}/jenkins-cli.jar' # Jenkins CLI destination
-  updates_dest: '{{ jenkins.dest }}/updates_jenkins.json' # Jenkins updates file
+  cli_dest: '{{ jenkins_dest }}/jenkins-cli.jar' # Jenkins CLI destination
+  updates_dest: '{{ jenkins_dest }}/updates_jenkins.json' # Jenkins updates file

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -4,8 +4,8 @@ jenkins:
     repo: 'deb http://pkg.jenkins-ci.org/debian binary/' # Jenkins repository
     key: 'http://pkg.jenkins-ci.org/debian/jenkins-ci.org.key' # Jenkins key
     dependencies: # Jenkins dependencies
-      - 'openjdk-6-jre'
-      - 'openjdk-6-jdk'
+      - 'openjdk-7-jre'
+      - 'openjdk-7-jdk'
       - 'git'
       - 'curl'
   dest: '/opt/jenkins'

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -9,5 +9,5 @@ jenkins:
       - 'git'
       - 'curl'
   dest: '/opt/jenkins'
-  cli_dest: '${jenkins.dest}/jenkins-cli.jar' # Jenkins CLI destination
-  updates_dest: '${jenkins.dest}/updates_jenkins.json' # Jenkins updates file
+  cli_dest: '{{ jenkins.dest }}/jenkins-cli.jar' # Jenkins CLI destination
+  updates_dest: '{{ jenkins.dest }}/updates_jenkins.json' # Jenkins updates file


### PR DESCRIPTION
According to a deprecation message, `${ }`-style variable interpolation is going away as of Ansible 1.6. This replaces it with `{{ }}` templates where appropriate.

It also fixes a self-reference within the `jenkins:` variable dictionary, which apparently [used to work by mistake](https://github.com/ansible/ansible/issues/2744).
