### PR TITLE
Making Jenkins startup delay configurable, defaulting to 10s.

### DIFF
--- a/tasks/cli.yml
+++ b/tasks/cli.yml
@@ -1,8 +1,8 @@
 ---
 # Handle plugins
-# If Jenkins is installed or updated, wait for pulling the Jenkins CLI, assuming 10s should be sufficiant
-- name: 10s delay while starting Jenkins
-  wait_for: port=8080 delay=10
+# If Jenkins is installed or updated, wait for pulling the Jenkins CLI
+- name: "{{ startup_delay_s | default(10) }}s delay while starting Jenkins"
+  wait_for: port=8080 delay={{ startup_delay_s | default(10) }}
   when: jenkins_install.changed
 
 # Create Jenkins CLI destination directory


### PR DESCRIPTION
For whatever reason, it takes about 15 seconds for Jenkins to be ready to serve HTTP requests in my environment. Until then, the "Get Jenkins CLI" task errors out with a 503.

This PR is to make the startup delay configurable, while defaulting to 10 seconds (which was the original value of the delay).
