### PR TITLE
Speed up provision: be more selective about `apt-get update`

### DIFF
--- a/tasks/dependencies_deb.yml
+++ b/tasks/dependencies_deb.yml
@@ -2,5 +2,5 @@
 # Install Jenkins dependencies
 - name: Install dependencies
   sudo: yes
-  action: "{{ ansible_pkg_mgr }} pkg={{ item }} state=installed update-cache=yes"
+  action: "{{ ansible_pkg_mgr }} pkg={{ item }} state=installed"
   with_items: jenkins.deb.dependencies

--- a/tasks/jenkins.yml
+++ b/tasks/jenkins.yml
@@ -10,7 +10,7 @@
 # Install Jenkins
 - name: Install Jenkins
   sudo: yes
-  action: "{{ ansible_pkg_mgr }} pkg=jenkins state=latest update-cache=yes"
+  action: "{{ ansible_pkg_mgr }} pkg=jenkins state=latest update_cache=yes cache_valid_time=86400"
   when: ansible_distribution in [ 'Debian', 'Ubuntu' ]
   register: jenkins_install
 

--- a/tasks/repo.yml
+++ b/tasks/repo.yml
@@ -16,8 +16,4 @@
 # Add Jenkins repository
 - name: Add Jenkins repository
   sudo: yes
-  action: apt_repository repo='{{ jenkins.deb.repo }}' state=present
-
-# Ugly workaround fixing the auto-add src repo when using apt_repository
-#- name: Remove invalid Jenkins src repository
-#  action: command sed --in-place '/deb-src.*pkg.jenkins-ci/d' /etc/apt/sources.list
+  action: apt_repository repo='{{ jenkins.deb.repo }}' state=present update_cache=yes

--- a/tasks/repo.yml
+++ b/tasks/repo.yml
@@ -2,11 +2,11 @@
 # Provides add-apt-repository
 - name: Install python-software-properties
   sudo: yes
-  action: "{{ ansible_pkg_mgr }} pkg=python-software-properties state=installed update-cache=yes"
+  action: "{{ ansible_pkg_mgr }} pkg=python-software-properties state=installed"
 
 - name: Install python-pycurl
   sudo: yes
-  action: "{{ ansible_pkg_mgr }} pkg=python-pycurl state=installed update-cache=yes"
+  action: "{{ ansible_pkg_mgr }} pkg=python-pycurl state=installed"
 
 # Add Jenkins repository key
 - name: Add jenkins apt-key


### PR DESCRIPTION
- Don't run apt-get update before each dependency
- Add a 24 hour cache freshness time for Jenkins package.
- Ensure we run `apt-get update` after adding the Jekins repo.

Making these changes significantly speeds up the process.
