### PR TITLE
Conditionally use the proxy environment.  This was causing a failure …

### DIFF
--- a/tasks/cli.yml
+++ b/tasks/cli.yml
@@ -14,10 +14,16 @@
   retries: 5
   delay: 10
 
-- name: Get Jenkins updates
+- name: Get Jenkins updates with proxy
   get_url: url=https://updates.jenkins-ci.org/update-center.json dest={{ jenkins.updates_dest }} thirsty=yes mode=0440 timeout=30 use_proxy={{proxy}}
   environment: proxy_env
   register: jenkins_updates
+  when: proxy
+
+- name: Get Jenkins updates without proxy
+  get_url: url=https://updates.jenkins-ci.org/update-center.json dest={{ jenkins.updates_dest }} thirsty=yes mode=0440 timeout=30 use_proxy={{proxy}}
+  register: jenkins_updates
+  when: not proxy
 
 - name: Update-center Jenkins
   shell: "cat {{ jenkins.updates_dest }} | sed '1d;$d' | curl -X POST -H 'Accept: application/json' -d @- http://localhost:{{ port }}/updateCenter/byId/default/postBack"


### PR DESCRIPTION
…of the role on my Vagrant setup.

I'm not a huge fan of it, and if proxy_env was used anywhere else I'd definitely look to see if we can use the proxy conditional on proxy_env, rather than on the tasks.  However, without a proxy, it seems to be broken, and this fixes it.
