### PR TITLE
Add ansible-galaxy install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,13 @@ Use this role to install Jenkins and install/update plugins.
 
 ## Usage
 
-### Get the code
+### Install from Ansible Galaxy
+
+```bash
+$ ansible-galaxy install flyapen.jenkins
+```
+
+### Or download manually
 
 ```bash
 $ git clone https://github.com/ICTO/ansible-jenkins.git roles


### PR DESCRIPTION
Its somewhat difficult to find this role on Ansible Galaxy. Instructions in the README would be really helpful.
