### PR TITLE
Prefix the variables in the role

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,14 +66,14 @@ with
 
 ```yaml
 ---
-plugins:
+jenkins_plugins:
   - 'ldap'
   - 'github'
   - 'translation'
   - 'preSCMbuildstep'
-port: 8081
-prefix: '/build'
-email:
+jenkins_port: 8081
+jenkins_prefix: '/build'
+jenkins_email:
   smtp_host: 'mail.example.com'
   smtp_ssl: 'true'
   default_email_suffix: '@example.com'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,21 +1,20 @@
 ---
-placeholder: 'placeholder'
-port: 8080
-# plugins:
+jenkins_port: 8080
+# jenkins_plugins:
 #   - 'ldap'
 #   - 'github'
 #   - 'translation'
 #   - 'preSCMbuildstep'
 #   - 'gravatar'
 
-proxy: no
-proxy_host: localhost
-proxy_port: 3128
-proxy_login: login
-proxy_password: password
-proxy_url: "http://{{proxy_login}}:{{proxy_password}}@{{proxy_host}}:{{proxy_port}}"
-__no_proxy: "localhost"
-proxy_env:
-  http_proxy: "{{proxy_url}}"
-  https_proxy: "{{proxy_url}}"
-  no_proxy: "{{__no_proxy}}"
+jenkins_proxy: no
+jenkins_proxy_host: localhost
+jenkins_proxy_port: 3128
+jenkins_proxy_login: login
+jenkins_proxy_password: password
+jenkins_proxy_url: "http://{{jenkins_proxy_login}}:{{jenkins_proxy_password}}@{{jenkins_proxy_host}}:{{jenkins_proxy_port}}"
+jenkins___no_proxy: "localhost"
+jenkins_proxy_env:
+  http_proxy: "{{jenkins_proxy_url}}"
+  https_proxy: "{{jenkins_proxy_url}}"
+  no_proxy: "{{jenkins___no_proxy}}"

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,4 +1,4 @@
 # Safe-restart Jenkins
 - name: Restart Jenkins
   sudo: yes
-  command: java -jar {{ jenkins.cli_dest }} -s http://localhost:{{ port }} safe-restart
+  command: java -jar {{ jenkins.cli_dest }} -s http://localhost:{{ jenkins_port }} safe-restart

--- a/tasks/cli.yml
+++ b/tasks/cli.yml
@@ -1,32 +1,32 @@
 ---
 # Handle plugins
 - name: "{{ startup_delay_s | default(10) }}s delay while starting Jenkins"
-  wait_for: host=localhost port={{ port }} delay={{ startup_delay_s | default(10) }}
+  wait_for: host=localhost port={{ jenkins_port }} delay={{ startup_delay_s | default(10) }}
   when: jenkins_install.changed or config_changed.changed
 
 - name: "Create Jenkins CLI destination directory: {{ jenkins_dest }}"
   file: path={{ jenkins_dest }} state=directory
 
 - name: Get Jenkins CLI
-  get_url: url=http://localhost:{{ port }}/jnlpJars/jenkins-cli.jar dest={{ jenkins.cli_dest }} mode=0440
+  get_url: url=http://localhost:{{ jenkins_port }}/jnlpJars/jenkins-cli.jar dest={{ jenkins.cli_dest }} mode=0440
   register: jenkins_local_cli
   until: "'OK' in jenkins_local_cli.msg or 'file already exists' in jenkins_local_cli.msg"
   retries: 5
   delay: 10
 
 - name: Get Jenkins updates
-  get_url: url=http://updates.jenkins-ci.org/update-center.json dest={{ jenkins.updates_dest }} thirsty=yes mode=0440 timeout=30 use_proxy={{proxy}}
-  environment: proxy_env
+  get_url: url=http://updates.jenkins-ci.org/update-center.json dest={{ jenkins.updates_dest }} thirsty=yes mode=0440 timeout=30 use_proxy={{jenkins_proxy}}
+  environment: jenkins_proxy_env
   register: jenkins_updates
-  when: proxy
+  when: jenkins_proxy
 
 - name: Get Jenkins updates without proxy
-  get_url: url=https://updates.jenkins-ci.org/update-center.json dest={{ jenkins.updates_dest }} thirsty=yes mode=0440 timeout=30 use_proxy={{proxy}}
+  get_url: url=https://updates.jenkins-ci.org/update-center.json dest={{ jenkins.updates_dest }} thirsty=yes mode=0440 timeout=30 use_proxy={{jenkins_proxy}}
   register: jenkins_updates
-  when: not proxy
+  when: not jenkins_proxy
 
 - name: Update-center Jenkins
-  shell: "cat {{ jenkins.updates_dest }} | sed '1d;$d' | curl -X POST -H 'Accept: application/json' -d @- http://localhost:{{ port }}/updateCenter/byId/default/postBack"
+  shell: "cat {{ jenkins.updates_dest }} | sed '1d;$d' | curl -X POST -H 'Accept: application/json' -d @- http://localhost:{{ jenkins_port }}/updateCenter/byId/default/postBack"
   when: jenkins_updates.changed
   notify:
     - 'Restart Jenkins'

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -5,12 +5,12 @@
   when: ansible_os_family == "RedHat"
 
 - name: Configure Jenkins Port for RedHat
-  lineinfile: dest=/etc/sysconfig/jenkins regexp=^JENKINS_PORT= line=JENKINS_PORT={{port}}
+  lineinfile: dest=/etc/sysconfig/jenkins regexp=^JENKINS_PORT= line=JENKINS_PORT={{jenkins_port}}
   register: config_changed
   when: ansible_os_family == "RedHat"
 
 - name: Configure Jenkins Port for Debian
-  lineinfile: dest=/etc/default/jenkins regexp=^HTTP_PORT= line=HTTP_PORT={{port}}
+  lineinfile: dest=/etc/default/jenkins regexp=^HTTP_PORT= line=HTTP_PORT={{jenkins_port}}
   register: config_changed
   when: ansible_os_family == "Debian"
 

--- a/tasks/plugins.yml
+++ b/tasks/plugins.yml
@@ -20,7 +20,7 @@
     - 'Restart Jenkins'
 
 - name: List plugins to be updated
-  shell: java -jar {{ jenkins.cli_dest }} -s http://localhost:{{ port }} list-plugins | grep ')$' | cut -f 1 -d ' ' | sed ':a;N;$!ba;s/\n/ /g'
+  shell: java -jar {{ jenkins.cli_dest }} -noKeyAuth -s http://localhost:{{ port }} list-plugins | grep ')$' | cut -f 1 -d ' ' | awk 1 ORS=' '
   register: plugins_updates
 
 - name: Update plugins

--- a/tasks/plugins.yml
+++ b/tasks/plugins.yml
@@ -1,32 +1,32 @@
 ---
 - template: src=proxy.groovy dest={{ jenkins_dest }}/proxy.groovy
-  when: proxy|bool
+  when: jenkins_proxy
 
 - name: add proxy settings configuration
-  shell: cat {{ jenkins_dest }}/proxy.groovy | java -jar {{ jenkins.cli_dest }} -s http://localhost:{{ port }} groovy =
-  when: proxy|bool
+  shell: cat {{ jenkins_dest }}/proxy.groovy | java -jar {{ jenkins.cli_dest }} -s http://localhost:{{ jenkins_port }} groovy =
+  when: jenkins_proxy
 
 - name: List plugins
-  shell: java -jar {{ jenkins.cli_dest }} -s http://localhost:{{ port }} list-plugins | cut -f 1 -d ' '
-  when: plugins is defined
-  register: plugins_installed
+  shell: java -jar {{ jenkins.cli_dest }} -s http://localhost:{{ jenkins_port }} list-plugins | cut -f 1 -d ' '
+  when: jenkins_plugins is defined
+  register: jenkins_plugins_installed
 
 - name: Install/update plugins
-  shell: java -jar {{ jenkins.cli_dest }} -s http://localhost:{{ port }} install-plugin {{ item }}
-  when: plugins_installed.changed and plugins_installed.stdout.find('{{ item }}') == -1
-  with_items: plugins
+  shell: java -jar {{ jenkins.cli_dest }} -s http://localhost:{{ jenkins_port }} install-plugin {{ item }}
+  when: jenkins_plugins_installed.changed and jenkins_plugins_installed.stdout.find('{{ item }}') == -1
+  with_items: jenkins_plugins
   ignore_errors: yes
   notify:
     - 'Restart Jenkins'
 
 - name: List plugins to be updated
-  shell: java -jar {{ jenkins.cli_dest }} -noKeyAuth -s http://localhost:{{ port }} list-plugins | grep ')$' | cut -f 1 -d ' ' | awk 1 ORS=' '
-  register: plugins_updates
+  shell: java -jar {{ jenkins.cli_dest }} -noKeyAuth -s http://localhost:{{ jenkins_port }} list-plugins | grep ')$' | cut -f 1 -d ' ' | awk 1 ORS=' '
+  register: jenkins_plugins_updates
 
 - name: Update plugins
-  shell: java -jar {{ jenkins.cli_dest }} -s http://localhost:{{ port }} install-plugin {{ item }}
-  with_items: plugins_updates.stdout.split()
-  when: plugins_updates.stdout != ''
+  shell: java -jar {{ jenkins.cli_dest }} -s http://localhost:{{ jenkins_port }} install-plugin {{ item }}
+  with_items: jenkins_plugins_updates.stdout.split()
+  when: jenkins_plugins_updates.stdout != ''
   ignore_errors: yes
   notify:
     - 'Restart Jenkins'

--- a/templates/proxy.groovy
+++ b/templates/proxy.groovy
@@ -2,10 +2,10 @@ import jenkins.model.*
 
 def instance = Jenkins.getInstance()
 
-final String name = "{{proxy_host}}"
-final int port = {{proxy_port}}
-final String userName = "{{proxy_login}}"
-final String password = "{{proxy_password}}"
+final String name = "{{jenkins_proxy_host}}"
+final int port = {{jenkins_proxy_port}}
+final String userName = "{{jenkins_proxy_login}}"
+final String password = "{{jenkins_proxy_password}}"
 final String noProxyHost = "localhost"
 
 final def pc = new hudson.ProxyConfiguration(name, port, userName, password, noProxyHost)


### PR DESCRIPTION
Will break most configs, but it's necessary because jenkins isn't the only plugin that has a `plugin` variable. 

Merges PR #33 as well
