### PR TITLE
Add authentication information to the jenkins cli call

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -20,3 +20,5 @@ proxy_env:
   https_proxy: "{{proxy_url}}"
   no_proxy: "{{__no_proxy}}"
 prefix: "/"
+# jenkins_admin_user: admin
+# jenkins_admin_password: recommended to be put a vault file

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,4 +1,4 @@
 # Safe-restart Jenkins
 - name: Restart Jenkins
   sudo: yes
-  command: java -jar {{ jenkins.cli_dest }} -s http://localhost:{{ port }}{{ prefix }} safe-restart
+  command: "{{ jenkins_cli_cmd }} safe-restart"

--- a/tasks/cli.yml
+++ b/tasks/cli.yml
@@ -8,7 +8,7 @@
   file: path={{ jenkins_dest }} state=directory
 
 - name: Get Jenkins CLI
-  get_url: url=http://localhost:{{ port }}{{ prefix }}/jnlpJars/jenkins-cli.jar dest={{ jenkins.cli_dest }} mode=0440
+  get_url: url="{{ jenkins_api_url }}jnlpJars/jenkins-cli.jar" dest="{{ jenkins.cli_dest }}" mode=0440
   register: jenkins_local_cli
   until: "'OK' in jenkins_local_cli.msg or 'file already exists' in jenkins_local_cli.msg"
   retries: 5
@@ -26,7 +26,7 @@
   when: not proxy
 
 - name: Update-center Jenkins
-  shell: "cat {{ jenkins.updates_dest }} | sed '1d;$d' | curl -X POST -H 'Accept: application/json' -d @- http://localhost:{{ port }}/updateCenter/byId/default/postBack"
+  shell: "cat {{ jenkins.updates_dest }} | sed '1d;$d' | curl -X POST -H 'Accept: application/json' -d @- {{ jenkins_api_url }}updateCenter/byId/default/postBack"
   when: jenkins_updates.changed
   notify:
     - 'Restart Jenkins'

--- a/tasks/jenkins.yml
+++ b/tasks/jenkins.yml
@@ -2,6 +2,13 @@
 
 - include: repo.yml
 
+- name: Log in to Jenkins CLI if auth config is available
+  # OK to ignore errors as it won't work before Jenkins is installed
+  ignore_errors: yes
+  command: >
+    {{ jenkins_cli_cmd }} login --username {{ jenkins_admin_user }} --password {{ jenkins_admin_password }}
+  when: jenkins_admin_user is defined and jenkins_admin_password is defined
+
 - include: dependencies_deb.yml
   when: ansible_os_family == "Debian"
 

--- a/tasks/plugins.yml
+++ b/tasks/plugins.yml
@@ -3,16 +3,16 @@
   when: proxy|bool
 
 - name: add proxy settings configuration
-  shell: cat {{ jenkins_dest }}/proxy.groovy | java -jar {{ jenkins.cli_dest }} -s http://localhost:{{ port }}{{ prefix }} groovy =
+  shell: cat {{ jenkins_dest }}/proxy.groovy | {{ jenkins_cli_cmd }} groovy =
   when: proxy|bool
 
 - name: List plugins
-  shell: java -jar {{ jenkins.cli_dest }} -s http://localhost:{{ port }}{{ prefix }} list-plugins | cut -f 1 -d ' '
+  shell: "{{ jenkins_cli_cmd }} list-plugins | cut -f 1 -d ' '"
   when: plugins is defined
   register: plugins_installed
 
 - name: Install/update plugins
-  shell: java -jar {{ jenkins.cli_dest }} -s http://localhost:{{ port }}{{ prefix }} install-plugin {{ item }}
+  shell: "{{ jenkins_cli_cmd }} install-plugin {{ item }}"
   when: plugins_installed.changed and plugins_installed.stdout.find('{{ item }}') == -1
   with_items: plugins
   ignore_errors: yes
@@ -20,12 +20,12 @@
     - 'Restart Jenkins'
 
 - name: List plugins to be updated
-  shell: java -jar {{ jenkins.cli_dest }} -noKeyAuth -s http://localhost:{{ port }}{{ prefix }} list-plugins | grep ')$' | cut -f 1 -d ' ' | awk 1 ORS=' '
+  shell: "{{ jenkins_cli_cmd }} -noKeyAuth list-plugins | grep ')$' | cut -f 1 -d ' ' | awk 1 ORS=' '"
   register: plugins_updates
   when: (ansible_os_family == "Debian" or ansible_os_family == "RedHat")
 
 - name: Update plugins
-  shell: java -jar {{ jenkins.cli_dest }} -s http://localhost:{{ port }}{{ prefix }} install-plugin {{ item }}
+  shell: "{{ jenkins_cli_cmd }} install-plugin {{ item }}"
   with_items: plugins_updates.stdout.split()
   when: plugins_updates.stdout != ''
   ignore_errors: yes

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -16,3 +16,5 @@ jenkins:
       - 'curl'
   cli_dest: '{{ jenkins_dest }}/jenkins-cli.jar' # Jenkins CLI destination
   updates_dest: '{{ jenkins_dest }}/updates_jenkins.json' # Jenkins updates file
+jenkins_api_url: "http://localhost:{{ port }}{{ prefix }}"
+jenkins_cli_cmd: "java -jar {{ jenkins.cli_dest }} -s {{ jenkins_api_url }}"


### PR DESCRIPTION
The jenkins setup I'm dealing with has all the security options removed for anonymous users. This patch introduces two new variables to the role: `jenkins_admin_user` and `jenkins_admin_password`. When _BOTH_ are defined, it will extend the string that contains the CLI command with the following snippet:

 `--username {admin_user} --password {admin_password}`

This will address issue #21.
