### PR TITLE
Flatten jenkins vars for overloading

### DIFF
--- a/tasks/cli.yml
+++ b/tasks/cli.yml
@@ -8,25 +8,25 @@
   file: path={{ jenkins_dest }} state=directory
 
 - name: Get Jenkins CLI
-  get_url: url="{{ jenkins_api_url }}jnlpJars/jenkins-cli.jar" dest="{{ jenkins.cli_dest }}" mode=0440
+  get_url: url="{{ jenkins_api_url }}jnlpJars/jenkins-cli.jar" dest="{{ jenkins_cli_dest }}" mode=0440
   register: jenkins_local_cli
   until: "'OK' in jenkins_local_cli.msg or 'file already exists' in jenkins_local_cli.msg"
   retries: 5
   delay: 10
 
 - name: Get Jenkins updates
-  get_url: url=http://updates.jenkins-ci.org/update-center.json dest={{ jenkins.updates_dest }} thirsty=yes mode=0440 timeout=30 use_proxy={{proxy}}
+  get_url: url=http://updates.jenkins-ci.org/update-center.json dest={{ jenkins_updates_dest }} thirsty=yes mode=0440 timeout=30 use_proxy={{proxy}}
   environment: proxy_env
   register: jenkins_updates
   when: proxy
 
 - name: Get Jenkins updates without proxy
-  get_url: url=https://updates.jenkins-ci.org/update-center.json dest={{ jenkins.updates_dest }} thirsty=yes mode=0440 timeout=30 use_proxy={{proxy}}
+  get_url: url=https://updates.jenkins-ci.org/update-center.json dest={{ jenkins_updates_dest }} thirsty=yes mode=0440 timeout=30 use_proxy={{proxy}}
   register: jenkins_updates
   when: not proxy
 
 - name: Update-center Jenkins
-  shell: "cat {{ jenkins.updates_dest }} | sed '1d;$d' | curl -X POST -H 'Accept: application/json' -d @- {{ jenkins_api_url }}updateCenter/byId/default/postBack"
+  shell: "cat {{ jenkins_updates_dest }} | sed '1d;$d' | curl -X POST -H 'Accept: application/json' -d @- {{ jenkins_api_url }}updateCenter/byId/default/postBack"
   when: jenkins_updates.changed
   notify:
     - 'Restart Jenkins'

--- a/tasks/dependencies_deb.yml
+++ b/tasks/dependencies_deb.yml
@@ -1,4 +1,4 @@
 ---
 - name: Install Debian dependencies
   apt: name={{ item }} state=installed
-  with_items: jenkins.deb.dependencies
+  with_items: '{{ jenkins_deb_dependencies }}'

--- a/tasks/dependencies_redhat.yml
+++ b/tasks/dependencies_redhat.yml
@@ -2,4 +2,4 @@
 
 - name: Install RedHat dependencies
   yum: name={{ item }} state=installed
-  with_items: jenkins.redhat.dependencies
+  with_items: '{{ jenkins_redhat_dependencies }}'

--- a/tasks/repo.debian.yml
+++ b/tasks/repo.debian.yml
@@ -7,7 +7,7 @@
   apt: name=python-pycurl state=installed
 
 - name: Add jenkins apt-key
-  apt_key: data="{{ lookup('file', 'jenkins-ci.org.key') }}" state=present
+  apt_key: url='{{ jenkins_deb_apt_key }}' state=present
 
 - name: Add Jenkins repository
-  apt_repository: repo='{{ jenkins.deb.repo }}' state=present update_cache=yes
+  apt_repository: repo='{{ jenkins_deb_repo }}' state=present update_cache=yes

--- a/tasks/repo.redhat.yml
+++ b/tasks/repo.redhat.yml
@@ -8,11 +8,11 @@
 
 - name: Import jenkins key
   rpm_key:
-    key: https://jenkins-ci.org/redhat/jenkins-ci.org.key
+    key: '{{ jenkins_redhat_key }}'
     state: present
     validate_certs: no
 
 - name: Get jenkins repo for ansible
   get_url:
-    url: http://pkg.jenkins-ci.org/redhat/jenkins.repo
+    url: '{{ jenkins_redhat_repo }}'
     dest: /etc/yum.repos.d/jenkins.repo

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,20 +1,25 @@
 ---
 jenkins_dest: /opt/jenkins
 jenkins_lib: /var/lib/jenkins
-jenkins:
-  deb:
-    repo: 'deb http://pkg.jenkins-ci.org/debian binary/' # Jenkins repository
-    dependencies: # Jenkins dependencies
+
+#Debain variables
+jenkins_deb_repo: 'deb http://pkg.jenkins-ci.org/debian binary/' # Jenkins repository
+jenkins_deb_apt_key: 'http://pkg.jenkins-ci.org/debian/jenkins-ci.org.key' # Jenkins repository apt-key
+jenkins_deb_dependencies:
       - 'openjdk-7-jre'
       - 'openjdk-7-jdk'
       - 'git'
       - 'curl'
-  redhat:
-    dependencies:
+
+#Redhat variables
+jenkins_redhat_repo: 'http://pkg.jenkins-ci.org/redhat/jenkins.repo'
+jenkins_redhat_key: 'https://jenkins-ci.org/redhat/jenkins-ci.org.key'
+jenkins_redhat_dependencies:
       - 'java'
       - 'git'
       - 'curl'
-  cli_dest: '{{ jenkins_dest }}/jenkins-cli.jar' # Jenkins CLI destination
-  updates_dest: '{{ jenkins_dest }}/updates_jenkins.json' # Jenkins updates file
+
+jenkins_cli_dest: '{{ jenkins_dest }}/jenkins-cli.jar' # Jenkins CLI destination
+jenkins_updates_dest: '{{ jenkins_dest }}/updates_jenkins.json' # Jenkins updates file
 jenkins_api_url: "http://localhost:{{ port }}{{ prefix }}"
-jenkins_cli_cmd: "java -jar {{ jenkins.cli_dest }} -s {{ jenkins_api_url }}"
+jenkins_cli_cmd: "java -jar {{ jenkins_cli_dest }} -s {{ jenkins_api_url }}"


### PR DESCRIPTION
This change is proposed in order to have a more fine grain control over
Jenkins install versions. With release of Jenkins 2.0 the current role
fails to install. This change allows for easy overriding of jenkins
variables in order to point to different mirrors.

Changes:
- Flatten the nested vars file
- Add jenkins namespacing prefixes.
- Abstracted out the debian apt_key and redhat repo and key urls in
  order to allow for variable overloading.
