### PR TITLE
add libselinux-python, if its absent.

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -11,6 +11,7 @@ jenkins:
       - 'curl'
   redhat:
     dependencies:
+      - 'libselinux-python'
       - 'java'
       - 'git'
       - 'curl'


### PR DESCRIPTION
fatal: [hostname]: FAILED! => {
    "changed": false,
    "failed": true,
    "invocation": {
        "module_args": {
            "backrefs": false,
            "backup": false,
            "content": null,
            "create": false,
            "delimiter": null,
            "dest": "/etc/sysconfig/jenkins",
            "directory_mode": null,
            "follow": false,
            "force": null,
            "group": null,
            "insertafter": null,
            "insertbefore": null,
            "line": "JENKINS_PORT=8080",
            "mode": null,
            "owner": null,
            "regexp": "^JENKINS_PORT=",
            "remote_src": null,
            "selevel": null,
            "serole": null,
            "setype": null,
            "seuser": null,
            "src": null,
            "state": "present",
            "unsafe_writes": null,
            "validate": null
        },
        "module_name": "lineinfile"
    },
    "msg": "Aborting, target uses selinux but python bindings (libselinux-python) aren't installed!"