### PR TITLE
Add support for Jenkins 2.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ Use this role to install Jenkins and install/update plugins.
 ## Provides
 
 1. Latest Jenkins server
-2. Jenkins plugins support
+2. Specify version of Jenkins for redhat installation supported.
+3. Jenkins plugins support
 
 ## Requires
 
@@ -46,7 +47,7 @@ with
 
 ```ini
 [jenkins]
-127.0.0.1 ansible_ssh_port=2222 ansible_ssh_user=vagrant ansible_ssh_private_key_file=~/.vagrant.d/insecure_private_key 
+127.0.0.1 ansible_ssh_port=2222 ansible_ssh_user=vagrant ansible_ssh_private_key_file=~/.vagrant.d/insecure_private_key
 ```
 
 ### Create host specific variables

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,7 +1,6 @@
 ---
 galaxy_info:
   author: Thomas Berton
-  owner: Thomas Berton
   description: Role to install Jenkins and install/update plugins
   license: MIT
   min_ansible_version: 1.4

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,6 +1,7 @@
 ---
 galaxy_info:
   author: Thomas Berton
+  owner: Thomas Berton
   description: Role to install Jenkins and install/update plugins
   license: MIT
   min_ansible_version: 1.4
@@ -19,4 +20,3 @@ dependencies: []
   # dependencies available via galaxy should be listed here.
   # Be sure to remove the '[]' above if you add dependencies
   # to this list.
-  

--- a/tasks/cli.yml
+++ b/tasks/cli.yml
@@ -14,7 +14,7 @@
 
 - name: Get Jenkins CLI
   get_url:
-    url: "{{ jenkins_api_url }}jnlpJars/jenkins-cli.jar"
+    url: "{{ jenkins_api_url }}/jnlpJars/jenkins-cli.jar"
     dest: "{{ jenkins.cli_dest }}"
     mode: 0440
   register: jenkins_local_cli
@@ -46,7 +46,7 @@
   when: not proxy
 
 - name: Update-center Jenkins
-  shell: "cat {{ jenkins.updates_dest }} | sed '1d;$d' | curl -X POST -H 'Accept: application/json' -d @- {{ jenkins_api_url }}updateCenter/byId/default/postBack"
+  shell: "cat {{ jenkins.updates_dest }} | sed '1d;$d' | curl -X POST -H 'Accept: application/json' -d @- {{ jenkins_api_url }}/updateCenter/byId/default/postBack"
   when: jenkins_updates.changed
   notify:
     - 'Restart Jenkins'

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -1,4 +1,39 @@
 ---
+- name: wait for jenkins.install.UpgradeWizard.state file to be available
+  wait_for:
+    path: "{{ jenkins_lib }}/jenkins.install.UpgradeWizard.state"
+
+- name: Bypass - jenkins.install.InstallUtil.lastExecVersion
+  copy:
+    src: "{{ jenkins_lib }}/jenkins.install.UpgradeWizard.state"
+    dest: "{{ jenkins_lib }}/jenkins.install.InstallUtil.lastExecVersion"
+    owner: "{{ jenkins_user }}"
+    group: "{{ jenkins_user }}"
+    remote_src: True
+
+- name: Ensure jenkins.install.InstallUtil.lastExecVersion has correct ownership
+  file:
+    path: "{{ jenkins_lib }}/jenkins.install.InstallUtil.lastExecVersion"
+    owner: "{{ jenkins_user }}"
+    group: "{{ jenkins_user }}"
+
+- stat: path="{{ jenkins_lib }}/secrets/initialAdminPassword"
+  register: adminpassword
+
+- name: Get jenkins_admin_password from initialAdminPassword if still in var/lib/jenkins/secrets
+  shell: cat "{{ jenkins_lib }}/secrets/initialAdminPassword"
+  register: jenkins_initial_admin_password
+  when: adminpassword.stat.exists == True
+
+- name: Set jenkins_admin_password from initialAdminPassword if still in var/lib/jenkins/secrets
+  set_fact: jenkins_admin_password="{{ jenkins_initial_admin_password.stdout }}"
+  when: adminpassword.stat.exists == True
+
+- name: Bypass - initialAdminPassword
+  shell: mv {{ jenkins_lib }}/secrets/initialAdminPassword {{ jenkins_admin_password_file }}
+  notify:
+    - Restart Jenkins
+  when: adminpassword.stat.exists == True
 
 - name: Create jenkins configuration for RedHat
   file:

--- a/tasks/dependencies_redhat.yml
+++ b/tasks/dependencies_redhat.yml
@@ -1,5 +1,9 @@
 ---
 
 - name: Install RedHat dependencies
-  yum: name={{ item }} state=installed
+  yum: name={{ item }} state=present update_cache=yes
   with_items: "{{ jenkins.redhat.dependencies }}"
+  register: task_result
+  until: task_result.rc == 0
+  retries: 10
+  delay: 5

--- a/tasks/jenkins.yml
+++ b/tasks/jenkins.yml
@@ -20,10 +20,23 @@
   register: jenkins_install
   when: ansible_os_family == "Debian"
 
-- name: Install Jenkins for RedHat
+- name: Install Latest Jenkins Version for RedHat
   yum: name=jenkins state=latest
   register: jenkins_install
-  when: ansible_os_family == "RedHat"
+  when:
+    - ansible_os_family == "RedHat"
+    - (jenkins_ver == "latest") or
+      (jenkins_ver == "") or
+      (jenkins_ver is not defined)
+
+- name: Install Specific Jenkins Version for RedHat
+  yum: name=jenkins-{{ jenkins_ver }} state=installed
+  register: jenkins_install
+  when:
+    - ansible_os_family == "RedHat"
+    - jenkins_ver is defined
+    - jenkins_ver != "latest"
+    - jenkins_ver != ""
 
 - name: Install Jenkins for FreeBSD
   pkgng: name=jenkins state=present

--- a/tasks/plugins.yml
+++ b/tasks/plugins.yml
@@ -18,7 +18,7 @@
 
 - name: Install/update plugins
   shell: "{{ jenkins_cli_cmd }} install-plugin {{ item }} --username {{ jenkins_admin_user }} --password {{ jenkins_admin_password }}"
-  when: plugins_installed.changed and plugins_installed.stdout.find('{{ item }}') == -1
+  when: jenkins_admin_user is defined and jenkins_admin_password is defined and plugins_installed.changed and plugins_installed.stdout.find('{{ item }}') == -1
   register: result
   until: result.rc == 0
   retries: 5

--- a/tasks/plugins.yml
+++ b/tasks/plugins.yml
@@ -19,6 +19,10 @@
 - name: Install/update plugins
   shell: "{{ jenkins_cli_cmd }} install-plugin {{ item }} --username {{ jenkins_admin_user }} --password {{ jenkins_admin_password }}"
   when: plugins_installed.changed and plugins_installed.stdout.find('{{ item }}') == -1
+  register: result
+  until: result.rc == 0
+  retries: 5
+  delay: 10
   with_items: "{{ plugins }}"
   ignore_errors: yes
   notify:

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -17,5 +17,6 @@ jenkins:
       - 'curl'
   cli_dest: '{{ jenkins_dest }}/jenkins-cli.jar' # Jenkins CLI destination
   updates_dest: '{{ jenkins_dest }}/updates_jenkins.json' # Jenkins updates file
-jenkins_api_url: "http://localhost:{{ port }}{{ prefix }}"
+jenkins_api_url: "http://localhost:{{ port }}"
 jenkins_cli_cmd: "java -jar {{ jenkins.cli_dest }} -s {{ jenkins_api_url }}"
+jenkins_admin_password_file: /root/initialAdminPassword

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -17,6 +17,6 @@ jenkins:
       - 'curl'
   cli_dest: '{{ jenkins_dest }}/jenkins-cli.jar' # Jenkins CLI destination
   updates_dest: '{{ jenkins_dest }}/updates_jenkins.json' # Jenkins updates file
-jenkins_api_url: "http://localhost:{{ port }}"
+jenkins_api_url: "http://localhost:{{ port }}{{ prefix }}"
 jenkins_cli_cmd: "java -jar {{ jenkins.cli_dest }} -s {{ jenkins_api_url }}"
 jenkins_admin_password_file: /root/initialAdminPassword


### PR DESCRIPTION
The primary purpose of this effort was to add support for installing Jenkins 2.x. The key part of that support is bypassing the Jenkins 2.x setup wizard.

Along the way, I also added retries for several tasks including plugin installation/update where I was seeing transient task failures that worked on subsequent playbook executions. 

Links relevant to the eis_ansible-jenkins role changes:

- https://github.com/EBSCOIS/eis_ansible-jenkins/tree/feature/plugin_config_support
- https://github.com/EBSCOIS/eis_ansible-jenkins/wiki/Purpose-and-Use-of-eis_ansible-jenkins